### PR TITLE
region fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,6 @@ resource "ibm_cos_bucket" "bucket_instance" {
   count                   = (var.provision ? 1 : 0)
   bucket_name             = local.bucket_name
   resource_instance_id    = var.cos_instance_id
-  cross_region_location   = var.region
+  region_location         = var.region
   storage_class           = var.storage_class
 }

--- a/test/stages/stage3-cos bucket.tf
+++ b/test/stages/stage3-cos bucket.tf
@@ -18,4 +18,5 @@ module "dev_cos_bucket" {
   name_prefix         = var.name_prefix
   ibmcloud_api_key    = var.ibmcloud_api_key
   name                = "my-test-bucket-${random_string.random.result}"
+  region              = var.region
 }

--- a/test/stages/variables.tf
+++ b/test/stages/variables.tf
@@ -10,6 +10,11 @@ variable "ibmcloud_api_key" {
   description = "The api key for IBM Cloud access"
 }
 
+variable "region" {
+  type        = string
+  description = "Region for VLANs defined in private_vlan_number and public_vlan_number."
+}
+
 variable "name_prefix" {
   type        = string
   description = "Prefix name that should be used for the cluster and services. If not provided then resource_group_name will be used"

--- a/variables.tf
+++ b/variables.tf
@@ -30,9 +30,8 @@ variable "name" {
 
 
 variable "region" {
-    description = "Cross-regional bucket location. Supported values are us, eu, and ap.  Default 'us'"
+    description = "Bucket region"
     type        = string
-    default     = "us"
 }
 
 variable "storage_class" {


### PR DESCRIPTION
Fixing region to work with flow log collectors.  In this case the regions must match.  The default, with global cross-region does not work as expected.