### PR TITLE
Connects bucket with Activity Tracker and Monitoring services

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -20,6 +20,16 @@ versions:
       refs:
         - source: github.com/ibm-garage-cloud/terraform-ibm-kms-key
           version: ">= 1.0.0"
+    - id: activity_tracker
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-activity-tracker
+          version: ">= 1.0.0"
+      optional: true
+    - id: metrics_monitoring
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-sysdig
+          version: ">= 1.0.0"
+      optional: true
   variables:
     - name: resource_group_name
       moduleRef:
@@ -33,6 +43,16 @@ versions:
       moduleRef:
         id: kms_key
         output: crn
+    - name: activity_tracker_crn
+      moduleRef:
+        id: activity_tracker
+        output: crn
+      optional: true
+    - name: metrics_monitoring_crn
+      moduleRef:
+        id: metrics_monitoring
+        output: crn
+      optional: true
     - name: ibmcloud_api_key
       scope: global
     - name: region

--- a/test/stages/stage1-activity-tracker.tf
+++ b/test/stages/stage1-activity-tracker.tf
@@ -1,0 +1,7 @@
+module "activity_tracker" {
+  source = "github.com/cloud-native-toolkit/terraform-ibm-activity-tracker"
+
+  resource_group_name      = module.resource_group.name
+  resource_location        = var.region
+  provision                = true
+}

--- a/test/stages/stage1-sysdig.tf
+++ b/test/stages/stage1-sysdig.tf
@@ -1,0 +1,9 @@
+module "monitoring" {
+  source = "github.com/cloud-native-toolkit/terraform-ibm-sysdig"
+
+  resource_group_name      = module.resource_group.name
+  ibmcloud_api_key         = var.ibmcloud_api_key
+  region                   = var.region
+  provision                = true
+  name_prefix              = var.name_prefix
+}

--- a/test/stages/stage3-cos-bucket.tf
+++ b/test/stages/stage3-cos-bucket.tf
@@ -13,11 +13,13 @@ resource "random_string" "random" {
 module "dev_cos_bucket" {
   source = "./module"
 
-  resource_group_name = module.resource_group.name
-  cos_instance_id     = module.cos.id
-  name_prefix         = var.name_prefix
-  ibmcloud_api_key    = var.ibmcloud_api_key
-  name                = "my-test-bucket-${random_string.random.result}"
-  region              = var.region
-  kms_key_crn         = module.hpcs_key.crn
+  resource_group_name    = module.resource_group.name
+  cos_instance_id        = module.cos.id
+  name_prefix            = var.name_prefix
+  ibmcloud_api_key       = var.ibmcloud_api_key
+  label                  = "bucket-${random_string.random.result}"
+  region                 = var.region
+  kms_key_crn            = module.hpcs_key.crn
+  activity_tracker_crn   = module.activity_tracker.crn
+  metrics_monitoring_crn = module.monitoring.crn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,15 @@ variable "kms_key_crn" {
   description = "The crn of the root key in the KMS"
   default     = null
 }
+
+variable "activity_tracker_crn" {
+  type        = string
+  description = "The crn of the Activity Tracking instance"
+  default     = null
+}
+
+variable "metrics_monitoring_crn" {
+  type        = string
+  description = "The crn of the Metrics Monitoring instance"
+  default     = null
+}


### PR DESCRIPTION
- Adds activity_tracker_crn and metrics_monitoring_crn input variables
- Connects the bucket to the activity tracker and monitoring instances if they are provided

Fixes #15

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>